### PR TITLE
Update 04.DataRecords.md

### DIFF
--- a/content/04.DataRecords.md
+++ b/content/04.DataRecords.md
@@ -1,6 +1,6 @@
 ## Data Records {.page_break_before}
 
-The final dataset that is provided here as open access contains 91,031 vegetation plots from 115 countries and all continents except Antarctica (Figure {@fig:Figure1}) and stems from 103 constitutive datasets (Table @tbl:Table1). It only contains the species composition of vascular plants, while information on the composition of mosses or lichens was discarded since it was only available for a minority of plots (n = 4,963 and n = 3,045, respectively).
+The final dataset that is provided here as open access contains 91,031 vegetation plots from 115 countries and all continents except Antarctica (Figure {@fig:Figure1}) and stems from 103 constitutive datasets (Table @tbl:Table1). It only contains the species composition of vascular plants, while information on the composition of bryophytes and lichens was discarded since it was only available for a minority of plots (n = 4,963 and n = 3,045, respectively).
 Information on the size (surface area) of the vegetation survey is available for 61,898 vegetation plots, and ranges between 0.01 m^2^ and 4 ha (mean = 270 m^2^; median = 78.5 m^2^). 
 The average number of vascular plant species per vegetation plot ranges between 1 (i.e. monospecific stands) and 270 species (mean = 17.6; median = 13). 
 


### PR DESCRIPTION
As mosses (correctly bryophytes) and lichens were mentioned as excluded, I think also algae and fungi should be mentioned (they occur in some datasets).
It sounds strange that more than 10,000 plots could not be decided whether they are from forest or non-forest.