### PR TITLE
Update 04.DataRecords.md

### DIFF
--- a/content/04.DataRecords.md
+++ b/content/04.DataRecords.md
@@ -15,7 +15,7 @@ The biomes ‘Temperate midlatitudes’ and ‘Subtropics with winter rain’ ha
 
 Finally, the dataset contains a relatively balanced number of forest (n = 25,832) vs. non forest (n = 38,203) vegetation plots, with a minor proportion of plots remaining unassigned (n = 10,050). 
 The assignment of plots to forests and non-forests is based on multiple lines of evidence, including the plot-level information on the cover of the tree layer, as well as traits of species composing a plot, such as growth form and height. 
-In short, a plot record was considered a forest if the cover of the tree layer, or alternatively, the sum of the relative cover of all tree taxa, was greater than 0.25. It was instead considered a non-forest record if the sum of relative cover of low‐stature, non‐tree and non‐shrub taxa was greater than 0.90. 
+In short, a plot record was considered a forest if the cover of the tree layer, or alternatively, the sum of the relative cover of all tree taxa, was greater than 0.25. It was instead considered a non-forest record if the sum of relative cover of low‐stature, non‐tree and non‐shrub taxa was greater than 0.90 and...
 For an extensive explanation on this classification scheme, we refer the reader to \[@doi:10.1111/jvs.12710\]. 
 Even if the proportion of forest vs. non-forest vegetation plots is relatively well-balanced, the geographical distribution of vegetation plots belonging to different vegetation types is likely not balanced in the geographical space, as it depends on the idiosyncrasies of the constitutive datasets composing the sPlot database. 
 For instance, the data from New Zealand only include plots collected in non-forest ecosystems, while data from Chile only refer to forests. 


### PR DESCRIPTION
this is strange, many forests have high cover of forest floor layer. Should not it be conditioned, e.g, cover of lower-stature, etc > 0.90 and sum of cover of trees < 0.25? Another comment: I find it strange to see the relative cover not in percentage but in fractions of 1