### PR TITLE
Update 02.BackgroundSummary.md

### DIFF
--- a/content/02.BackgroundSummary.md
+++ b/content/02.BackgroundSummary.md
@@ -35,7 +35,7 @@ Established in 2013, sPlot currently contains more than 1.9 million vegetation p
 The sPlot database is increasingly being used to study continental-to-global scale vegetation patterns, such as the relative contribution of regional vs. local factors on the global patterns of fern richness (@doi:10.1111/jbi.13782), the mechanisms underlying the spread and abundance of native vs. invasive tree species (@doi:10.1111/geb.13027), and worldwide trait–environment relationships in plant communities (@doi:10.1038/s41559-018-0699-8).  
 
 
-Here, we provide an open-access data set composed of 91,056 vegetation plots, representative of the environmental space covered by the sPlot database. 
+Here, we provide an open-access data set composed of 91,056 vegetation plots, that represent the entire environmental space covered by the sPlot database, to provide a standardized dataset for ecological research. 
 The selected vegetation plots stem from 104 databases and span 115 countries (Figure {@fig:Figure1}). 
 This resampled dataset (sPlot Open - hereafter) is composed of: 
 (1) plot-level information, including metadata and basic vegetation structure descriptors; 


### PR DESCRIPTION
I think the reason why this database is created should be put more forward: E.g. "Here, we provide an open-access data set composed of 91,056 vegetation plots, that represent the entire environmental space covered by the sPlot database, to provide a standardized dataset for ecological research." Can be different though, but I think it should be clear to the reader immoderately why this dataset is needed and why its different to sPlot.