### PR TITLE
Update 03.Methods.md

### DIFF
--- a/content/03.Methods.md
+++ b/content/03.Methods.md
@@ -12,8 +12,8 @@ Data in the sPlot database are unevenly distributed across continents and biomes
 Mid-latitude regions in developed countries (mostly Europe, the USA and Australia) are overrepresented, while regions in the tropics and subtropics are underrepresented, which is a typical geographical bias in biodiversity data (e.g., @doi:10.1111/ecog.00967; @doi:10.1038/s41559-020-1198-2). 
 To reduce this imbalance to the extent possible, we performed a stratified resampling approach, using several environmental variables available at global extent as sampling strata. 
 We considered 30 climatic and soil variables. 
-For climate, we complemented the 19 bioclimatic variables from CHELSA v1.2 (@doi:10.1038/sdata.2017.122), as well as two variables reflecting the growing-season (growing degree days above 1 °C - GDD1 - and 5 °C - GDD5), which were derived from CHELSA v1.2 using [....]. 
-In addition, we considered an index of aridity (AR) based on [...?] and a model for Potential Evapotranspiration (PET - @https://doi.org/10.6084/m9.figshare.7707605.v3). 
+For climate, we complemented the 19 bioclimatic variables from CHELSA v1.2 (@doi:10.1038/sdata.2017.122), as well as two variables reflecting the growing-season (growing degree days above 1 °C - GDD1 - and 5 °C - GDD5), which were derived from CHELSA v1.2 using monthly average temperatures. Specifically we summed the number of days of those months with average temperature greater than 1 °C or 5 °C, respectively. 
+In addition, we considered an index of aridity and a layer for Potential Evapotranspiration from the Consortium of Spatial Information (CGIAR-CSI) @https://doi.org/10.6084/m9.figshare.7707605.v3). 
 For soil, we extracted seven variables from the SOILGRIDS database (@doi:10.1371/journal.pone.0169748), namely: soil organic carbon content in the fine earth fraction, cation exchange capacity, pH, as well as the fractions of coarse fragments, sand, silt and clay.  
 
 We stratified our sampling effort based on the following procedure. 

--- a/content/03.Methods.md
+++ b/content/03.Methods.md
@@ -12,8 +12,8 @@ Data in the sPlot database are unevenly distributed across continents and biomes
 Mid-latitude regions in developed countries (mostly Europe, the USA and Australia) are overrepresented, while regions in the tropics and subtropics are underrepresented, which is a typical geographical bias in biodiversity data (e.g., @doi:10.1111/ecog.00967; @doi:10.1038/s41559-020-1198-2). 
 To reduce this imbalance to the extent possible, we performed a stratified resampling approach, using several environmental variables available at global extent as sampling strata. 
 We considered 30 climatic and soil variables. 
-For climate, we complemented the 19 bioclimatic variables from CHELSA (@doi:10.1038/sdata.2017.122), as well as two variables reflecting growing-season warmth (growing degree days above 1 °C - GDD1 - and 5 °C - GDD5), which we calculated based on CHELSA bioclimatic variables. 
-In addition, we considered an index of aridity (AR) and a model for Potential Evapotranspiration (PET - @https://doi.org/10.6084/m9.figshare.7707605.v3). 
+For climate, we complemented the 19 bioclimatic variables from CHELSA v1.2 (@doi:10.1038/sdata.2017.122), as well as two variables reflecting the growing-season (growing degree days above 1 °C - GDD1 - and 5 °C - GDD5), which were derived from CHELSA v1.2 using [....]. 
+In addition, we considered an index of aridity (AR) based on [...?] and a model for Potential Evapotranspiration (PET - @https://doi.org/10.6084/m9.figshare.7707605.v3). 
 For soil, we extracted seven variables from the SOILGRIDS database (@doi:10.1371/journal.pone.0169748), namely: soil organic carbon content in the fine earth fraction, cation exchange capacity, pH, as well as the fractions of coarse fragments, sand, silt and clay.  
 
 We stratified our sampling effort based on the following procedure. 


### PR DESCRIPTION
Chelsa version should be mentioned, as there is more than one.
"as well as two variables reflecting the growing-season (growing degree days above 1 °C - GDD1 - and 5 °C - GDD5), which were derived from CHELSA v1.2 using [....]. "
Please give a sentence how these have been derived exactly? How did you get them from the bioclim variables? I can only imagine to get them from the monthly climatologies (e.g. via a spline interpolation). Did you use the ones from Bruehlheide 2019, Nature Eco-Evo? Then we need to cite that.