### PR TITLE
Add environmental data to header matrix? +edits.

### DIFF
--- a/content/05.DatabaseOrganization.md
+++ b/content/05.DatabaseOrganization.md
@@ -15,14 +15,14 @@ This can take seven values: 'CoverPerc' = percentage cover, 'pa' = presence-abse
 
 The **'CWM_CWV'** matrix contains the community-weighted means and variances calculated for each of the 18 functional traits mentioned above. It also contains three additional columns. The column *'Species_richness'* returns the number of species recorded in each plot. The columns *'Trait_coverage_cover'* and *'Trait_coverage_pa'* return, respectively, the proportion of total cover and species in a plot for which functional trait information was available. Functional trait information was available for 20,932 species. 
 The average proportion of species in each plot for which we have functional trait information is 0.88 (median = 1). 
-For 47,177 plots, the coverage is complete, while only in one plot we have no functional trait information for any of the occurring species. 
+For 47,177 plots, the coverage is complete, while for only one plot do we have no functional trait information for any of the species occurring in it. 
 When considering relative cover, the average trait coverage is 0.89. As many as 68,234 and 74,388 plots have functional trait information for more than 80% of the species or 80% of relative cover, respectively.
 
 sPlot Open contains two additional objects. The **'metadata'** matrix contains plot-level metadata, which provide information on the origin of each individual vegetation plot. 
 This object contains 15 columns, with information on the dataset of origin (column *'GIVD_ID'* - @doi:10.1111/j.1654-1103.2011.01265.x), author or surveyor names (columns *'Releve_author'* and *'Releve_coauthor'*), bibliographic references both at the dataset (column *'DB_BIBTEXKEY'*) and plot level (*'Plot_Biblioreference'* and *'BIBTEXKEY'*), when available. 
 Similarly, the column *'Project_name'* provides information on the project in which a vegetation plot was collected.
 When available, we also provide information on the numbering of the plots in the publication where they originally appeared (columns *'Nr_table_in_publ'*, *'Nr_releve_in_table'*), or in the dataset where they were initially stored (*'Original_nr_in_database'*). 
-In case of nested plots (n = 1,786), we also provide the original plot and subplot IDs (columns: *'Original_plotID'*, *'Original_subplotID'*). 
+In the case of nested plots (n = 1,786), we also provide the original plot and subplot IDs (columns: *'Original_plotID'*, *'Original_subplotID'*). 
 The last two columns report plot-level *'Remarks'*, and the unique identifier produced by Turboveg when the vegetation plot was first stored (*'GUID'*). 
 
 


### PR DESCRIPTION
I have also made a few minor edits to this section, but mainly I have comments and I am not sure how to include them in this system, so I am adding them here:
* Given that we describe how we used climate and other environmental data to stratify the plot selection, it seems odd not to add those data to the header matrix.  Perhaps those data cannot be shared in this way?  If so then it may be worth mentioning that?  Anyway, I thought I would suggest this in case it is feasible.
* Where it says "Functional trait information was available for 20,932 species", was this before or after gap-filling?
* Some of the references are blank in Table 2. I guess that is because there is no publication associated with some of the datasets? I suggest explaining this in the paragraph that talks about the object 'references'.
* I also suggest explaining somewhere in this section that a releve is another word for a vegetation plot (not everyone will know this).