### PR TITLE
Update 03.Methods.md

### DIFF
--- a/content/03.Methods.md
+++ b/content/03.Methods.md
@@ -39,7 +39,7 @@ The resampling procedure resulted in a preliminary potential selection of 98,383
 Since the sPlot database is a consortium of independent datasets whose copyright belongs to the data contributor, we used this preliminary potential selection to ask each dataset’s custodian (i.e., either the owner of a dataset or its authorized representative in case of a collective dataset) for permission to release the data of each selected vegetation plot as open access. 
 For 8,070 vegetation plots, permission could not be granted because, for instance, the data are unpublished, confidential or sensitive. 
 For these vegetation plots, we used the reserve pool to randomly select replacements, for which such permission could be granted. 
-We imposed the constraint that each vegetation plot in the reserve should belong to the same environmental stratum, i.e., the same PC1-PC2 grid cell, of the confidential vegetation plot. 
+We imposed the constraint that each candidate vegetation plot in the reserve pool should belong to the same environmental stratum, i.e., the same PC1-PC2 grid cell, of the confidential vegetation plot. 
 Note that 2,380 PC1-PC2 grid cells (11.7% of total) had one or more confidential vegetation plots (median = 1, mean = 3.4, max = 171) that could not be replaced from the reserve pool.
 
 ### Trait information


### PR DESCRIPTION
In addition to my minor proposed edits, in the section 'Permission to release...' I think we should make it clearer how the open dataset ended up with 91,205 vegetation plots. It is far from obvious from the numbers in this paragraph how we ended up with that number!
In the 'Trait information' section, I find the description of gap-filling confusing.  For any given plot, what trait values are there?  Is it individually measured traits or species-level values?  Not clear, though the passage describing CWM and CWV calculations suggests species-level values.  In that case, what is meant by the sentence "Gap-filling was performed at the level of individual observations"?