### PR TITLE
Update 04.DataRecords.md

### DIFF
--- a/content/04.DataRecords.md
+++ b/content/04.DataRecords.md
@@ -8,7 +8,8 @@ By capping the number of vegetation plots in overrepresented environmental condi
 Yet, due to the lack or scarcity of data from some geographical regions, like the tropics, the spatial distribution of vegetation plots remains unbalanced across geographical regions (Figure {@fig:Figure1}). This is evident when comparing the number of plots across continents or biomes. 
 Europe is by far the best represented continent, with 53,884 vegetation plots. 
 In contrast, in Africa and South America the remaining plots after data edition and selectionwere 4,507 and 5,533 vegetation plots, respectively. 
-The representation of biomes is also unbalanced (Figure {@fig:Figure2}). Yet, all Whittaker biomes are covered by sPlot Open.
+The representation of biomes is also unbalanced (Figure {@fig:Figure2}). 
+Despite these imbalances, all the Whittaker biomes are covered by sPlot Open, and our resampling algorithm has resulted in a much more balanced dataset then many other large global datasets that are available, such as GBIF. 
 
 ![Distribution of all the vegetation plots provided by sPlot Open (n = 91,205) in the bi-dimensional climatic space represented by mean annual temperature and mean annual precipitation superimposed onto Whittaker biomes (@Whittaker1975)](images/figure2.png){#fig:Figure2}
 


### PR DESCRIPTION
In addition to my edits, I have a comment that some of the numbers are hard to understand.  Specifically:
"sPlot Open contains a relatively balanced number of forest (n = 25,832) vs. non forest (n = 38,203) vegetation plots, with a minor proportion of plots remaining unassigned (n = 10,050)."  These numbers add up to about 74,000 plots, which begs the question of why the other 18,000 plots are neither forest nor non-forest.  I think we need clearer explanation of this, and also of many of the rows in Table 2 that have similar issues.
In Table 2, for me there is not enough information here to understand many of the variables.  Is there a source of more detailed info anywhere?  If so, we should point to it clearly.  Examples of questions arising from Table 2:
* Why are there ~500 plots without a 'continent' assignation?
* Why do 30,000 plots not have a size (Releve_area)?
* Why do 80,000 plots not have either true or false for Herbs_identified?
* Why do 35,000 plots not have either true or false for is_forest?
* Why do 2,000 plots not have either true or false for is_nonforest?
* Why do 180 plots have no entry for Plant_recorded?
And so on.  These things need to be explained somewhere, and it is not clear to me that they are.