### PR TITLE
Update 06.TechnicalValidation.md

### DIFF
--- a/content/06.TechnicalValidation.md
+++ b/content/06.TechnicalValidation.md
@@ -3,13 +3,13 @@
 The original sPlot database has a nested structure and is composed of several individual datasets, each validated and maintained by its respective dataset custodian. 
 In many cases, individual datasets are also collections whose vegetation plots were provided by their respective owners (the person who performed the actual vegetation survey) or by someone who digitized the original data from the scientific or grey literature. 
 We obviously have no direct control over the individual vegetation plots that we provide here in sPlot Open. 
-Yet, each of these vegetation plots stem from trained professional botanists, or published scientific work, and are accompanied by detailed information on the sampling protocols used, thus ensuring data quality and reliability.  
+Yet, all of these vegetation plots stem from trained professional botanists, or published scientific work, and are accompanied by detailed information on the sampling protocols used, thus ensuring data quality and reliability.  
 
-Before integration into the sPlot database, each dataset was further checked for consistency and, if having a different format, was converted to a Turboveg 2 database (@doi:10.2307/3237010). 
+Before integration into the sPlot database, each dataset was further checked for consistency and, if it had a different format, was converted to a Turboveg 2 database (@doi:10.2307/3237010). 
 During this conversion, we checked that all datasets contained the required metadata information, and cross-checked that each plot was located within the geographic scopes of its respective dataset. 
 Finally, we harmonized all the taxonomic names from all datasets, based on the sPlot’s taxonomic backbone (@doi:10.5281/zenodo.845445). 
 This backbone matched all the taxonomic names (without nomenclatural authors) from all datasets in sPlot 2.1 and TRY v3.0 (@https://doi.org/10.1111/gcb.14904) to their resolved version based on the Taxonomic Name Resolution Service web application (TNRS version 4.0; @doi:10.1186/1471-2105-14-16; iPlant Collaborative, 2015). 
-This allowed to (1) harmonize all datasets to a common nomenclature, and (2) link the sPlot database to the TRY database (@https://doi.org/10.1111/gcb.14904). 
+This allowed us to (1) harmonize all datasets to a common nomenclature, and (2) link the sPlot database to the TRY database (@https://doi.org/10.1111/gcb.14904). 
 All taxa originally denoted at taxonomic ranks lower than species were aggregated at species level. 
 Additional detail on the taxonomic resolution is reported in Bruelheide et al. (2019) \[@doi:10.1111/jvs.12710\], while a description of the workflow, including R‐code, is available in Purschke (2017) \[@doi:10.5281/zenodo.845445\].
 


### PR DESCRIPTION
As well as my edits, some queries:
"All taxa originally denoted at taxonomic ranks lower than species were aggregated at species level." How was this aggregation done?  For example, if an average value taken, was it the mean or median?  Should be explained.
***My biggest concern is in the ‘Usage Notes’, where it says “As a rule, sPlot Open users should get in touch with the custodian(s) of the data they are planning to use.”  Why should users do this?  First, it is not clear what the point of this is (perhaps as a courtesy, or to invite authorship?)  Importantly, either way, it seems like strings attached, so this is an important issue. I do not think it is valid to claim that the data are open access while also saying that users of the data should get in touch with the custodians. In my opinion it would be fine to say that users are ‘encouraged’ to do this, but not to say that they 'should'.  On the other hand, I think it is OK (and a good idea) to say that users 'should' cite all the relevant sources of the data they used (where possible).  Currently this is only really made clear for BioTIME data, and not for the other data sources, so I suggest adding that in (though perhaps there is a reason not to?).