### PR TITLE
Update 03.Methods.md

### DIFF
--- a/content/03.Methods.md
+++ b/content/03.Methods.md
@@ -22,14 +22,14 @@ We considered the full environmental space of all terrestrial habitats on Earth 
 We then subdivided the PCA ordination space based on all terrestrial habitats into a regular 100 × 100 grid, limitedly to the first two principal components (PC1–PC2), which accounted for 47% and 23% of the total variation, respectively. 
 This PC1-PC2 bidimensional space was subsequently used to balance our sampling effort across all PC1-PC2 grid cells for which vegetation plots are available.
 Before projecting vegetation plots from the sPlot database v2.1 onto this PC1-PC2 environmental space, we removed vegetation plots: from wetlands; from anthropogenic vegetation types; without geographical coordinates; and with a location uncertainty higher than 3 km for those having geographical coordinates. 
-This led to a total of 799,400 out of the initial set of 1,121,244 vegetation plots. 
+This resulted in a total of 799,400 out of the initial set of 1,121,244 vegetation plots. 
 When projecting the 799,400 vegetation plots in the PC1-PC2 grid, we calculated how many vegetation plots occurred in each PC1-PC2 grid cell. 
 For those grid cells with more than 50 vegetation plots (n = 858), we selected up to 50 vegetation plots using the heterogeneity-constrained random resampling algorithm from Lengyel et al. (2011) \[@doi:10.1111/j.1654-1103.2010.01225.x\]. 
 This approach optimizes the selection of a random subset of vegetation plots that encompasses the highest variability in species composition while avoiding peculiar and rare communities, which may represent outliers. 
 We based the quantification of variability in plant species composition among the 50 randomly selected vegetation plots by computing the mean and the variance of the Jaccard’s dissimilarity index (@doi:10.1111/j.1469-8137.1912.tb05611.x) between all possible pairs of vegetation plots for a given random selection of 50 vegetation plots (n = 1225). 
 More precisely, for a given PC1-PC2 grid cell containing more than 50 vegetation plots, we generated 1,000 random selections of 50 vegetation plots and ranked them according to the mean (ascending order) and variance (descending order) value. 
 Ranks from both sortings were summed for each random selection, and the selection with the lowest summed rank was considered to provide the most balanced/even representation of vegetation types within the focal grid cell. 
-In case a grid cell contained fewer than 50 plots, we retained all of them. 
+Where a grid cell contained fewer than 50 plots, we retained all of them. 
 In this way, we reduced the imbalance towards over-sampled climate types while ensuring that the resampled dataset represents the entire environmental gradient covered by the sPlot database.
 We repeated the resampling procedure three times to get three different possibilities of a heterogeneity-constrained selection of 50 vegetation plots per PC1-PC2 grid cell with, initially, more than 50 vegetation plots. 
 Vegetation plots selected during the first iteration were our first choice, while we considered the vegetation plots additionally selected in the second and third iteration as reserves when asking for permission to release the data as open access to each dataset’s contributor(s).  


### PR DESCRIPTION
I am very concerned about applying the gap-filling method to assign traits from TRY to New Zealand species.  Given our high rate of endemism -- 80% of the flora -- what are the implications of using this approach?  It's not as if trait values may even exist for closely related taxa. I found the cited papers for the method quite dense and it will take me a lot of effort to get my head around this method.  But I would be worried if there is some kind of bias in the trait values and then naive users of the dataset will just accept them and come up with wonky predictions and conclusions for our part of the globe.
   I have encountered a different sort of problem when NZ species occurrence data were intersected with a global database of bark thickness.  In this example, they only retained species that were represented in the database and these were all introduced to NZ (northern hemisphere conifers).  This led to the completely wrong conclusion that NZ is dominated by thick-barked trees which would imply fire adaptation, whereas the opposite is true.  I assume the gap-filling technique is meant to overcome this.  I think there needs to be a bit more description provided here about how this gap filling works and what the limitations might be.  Alternatively, it could be useful to present a table of countries and the % of the species that required gap filling to derive traits.