### PR TITLE
Update 05.DatabaseOrganization.md

### DIFF
--- a/content/05.DatabaseOrganization.md
+++ b/content/05.DatabaseOrganization.md
@@ -30,4 +30,4 @@ Finally, the object **'references'**, contains all the bibliographic references 
 Each reference is tagged with a key corresponding to the fields *'DB_BIBTEXKEY'* and *'BIBTEXKEY'* in the metadata. 
 We further provide an R function (*'sPlotOpen_citation'*) to create reference lists, based on a selection of plots and/or datasets.
 
-Except for the 'reference' file (format .bib), all objects/matrices are provided in tab-delimited .txt files. All objects, including the 'sPlotOpen_citation' function, are also compiled inside an .RData object.
+Except for the 'reference' file (format .bib), all objects/matrices are provided in tab-delimited .txt files. All objects, including the 'sPlotOpen_citation' function, are also compiled inside an .RData object. 


### PR DESCRIPTION
I can't find Table 2.
I assume that if the original data are not percentage cover, then you didn't calculate Relative cover.
In the CWM_CMV matrix I think it is important to give a statistic to make clear the proportion of species trait values that are 'real' versus those that are gap-filled.  I would also like to know how many plots only had gap-filled traits.  It could be worthwhile to have a figure like Figure 1 that shows this globally,i.e. the proportion of records in the species X plot matrix for each hexagonal cell that are gap-filled.

Does it violate privacy regulations to be providing the names of the Releve author's in a database?  I would expect their permission would be required.

I don't understand with the object 'references' is referring to.  I certainly never provided any associated references for the plot data I provided to sPlot.