### PR TITLE
Update 02.BackgroundSummary.md

### DIFF
--- a/content/02.BackgroundSummary.md
+++ b/content/02.BackgroundSummary.md
@@ -3,24 +3,24 @@
 
 Biodiversity is facing a global crisis. 
 As many as 1 million species are currently threatened with extinction, the vast majority due to anthropogenic impacts such as land-use and climate change (@ipbes2019, @isbn:9782940529902). 
-In addition, the rates of biodiversity homogenization and redistribution are accelerating (@doi:10.1038/s41586-020-2640-y, @doi:10.1038/s41559-020-1198-2; @doi:10.1038/s41559-020-1176-8). 
+In addition, the rates of species migration and biotic homogenization are accelerating (@doi:10.1038/s41586-020-2640-y, @doi:10.1038/s41559-020-1198-2; @doi:10.1038/s41559-020-1176-8). 
 Biological assemblages are becoming progressively more similar to each other globally, as local and endemic species go extinct and are replaced by more widespread and competitive native or alien species (@ipbes2019; @doi:10.1038/s41559-020-1176-8). 
 Many terrestrial and marine species are also shifting their geographical distribution as a response to climate change (@doi:10.1038/s41559-020-1198-2), including animals hosting pathogens transmissible to humans (@doi:10.1038/nature06536; @doi:10.1126/science.1244325). 
-This has profound potential impacts on human and ecosystem health (@doi:10.1126/science.aai9214;  @doi:10.1111/brv.12344). 
+This has profound potential impacts on ecosystems and human health (@doi:10.1126/science.aai9214;  @doi:10.1111/brv.12344). 
 
 
 Plant communities are no exception to this biodiversity crisis (@doi:10.1126/science.1156831; @doi:10.3732/ajb.1000364; @doi:10.1038/s41559-020-1176-8). 
 This is worrisome since terrestrial vegetation accounts for 80% (450 Gt C) of the living biomass on Earth (@doi:10.1073/pnas.1711842115). 
-Given the central role of vegetation in ecosystem productivity, stability and functioning (@doi:10.3732/ajb.1000364), assessing biodiversity status and trends in plant communities is paramount for other kingdoms of life and human societies alike.  
+Given the central role of vegetation in ecosystem productivity, structure, stability and functioning (@doi:10.3732/ajb.1000364), assessing biodiversity status and trends in plant communities is paramount for other kingdoms of life and human societies alike.  
 
 
 Monitoring trends in plant biodiversity requires adequate data across a range of spatiotemporal scales (@doi:10.1016/j.oneear.2020.09.010, @doi:10.1002/ppp3.10160). 
 Large independent collections of plant occurrence data do exist at the global or continental extent via the Botanical Information and Ecology Network (BIEN) (@doi:10.7287/peerj.preprints.2615v2), the Global Inventory of Floras and Traits (GIFT) (@doi:10.1111/jbi.13623) or the Global Biodiversity Information Facility (GBIF) (https://www.gbif.org/). 
-However, these presence-only databases either neglect how individual plant species co-occur and interact locally to form plant communities, or are collected at spatial resolutions which are too coarse to assess biodiversity trends (e.g., one‐degree grid cells) at the plant community scale (@doi:10.1371/journal.pbio.1000385).  
+However, these presence-only databases either neglect how individual plant species co-occur and interact locally to form plant communities, or are collected at spatial resolutions which preclude intersection with high resolution remote sensing data and are too coarse to assess biodiversity trends (e.g., one‐degree grid cells) at the plant community scale (@doi:10.1371/journal.pbio.1000385).  
 
-Yet, there is a long tradition among botanists to record the cover or abundance of each plant species that occurs in a vegetation plot of a given size (i.e. surface area) at a given time (e.g. @Stebler1893). 
+Yet, there is a long tradition among botanists to record the cover or abundance of each plant species that occurs in a vegetation plot location of a given size (i.e. surface area) at a given time (e.g. @Stebler1893). 
 Compared to presence-only data, vegetation-plot data (termed 'presence-absence' here) present many advantages. 
-First, they contain information on which plant species do, and do not, co‐occur in the same locality at a given moment in time (@doi:10.1111/avsc.12191). 
+As all visible plant species are recorded, plots contain information on which plant species do, and do not, co‐occur in the same locality at a given moment in time (@doi:10.1111/avsc.12191). 
 This is important for testing hypotheses related to biotic interactions among plant species. 
 Vegetation-plot data also provide crucial information on where and when a species was absent, therefore improving predictions from current species distribution models (@doi:10.1890/07-2153.1). 
 Being spatially explicit, vegetation plots can be resurveyed through time to assess potential changes in plant species composition relative to a baseline (@doi:10.1111/gcb.14030; @doi:10.1038/s41586-018-0005-6, @doi:10.1038/s41559-020-1176-8). 
@@ -32,7 +32,7 @@ Furthermore, with their disparate sampling protocols, standards and taxonomic re
 It is not surprising, therefore, that these data are rarely used in global‐scale biodiversity research (@doi:10.1111/geb.12501; @doi:10.1111/jvs.12419; @doi:10.1111/jvs.12864).  
 
 The sPlot initiative tries to close this data gap. 
-It leverages numerous local-to-regional vegetation-plot datasets to create a harmonized and comprehensive global database of georeferenced terrestrial plant species assemblages (@doi:10.1111/jvs.12710). 
+It consolidates numerous local to regional vegetation-plot datasets to create a harmonized and comprehensive global database of georeferenced terrestrial plant species assemblages (@doi:10.1111/jvs.12710). 
 Established in 2013, sPlot (version 3) currently contains more than 1.9 million vegetation plots, and is fully integrated with the TRY database (@https://doi.org/10.1111/gcb.14904), from which it derives information on plant functional traits. 
 The sPlot database is increasingly being used to study continental-to-global scale vegetation patterns, such as the relative contribution of regional vs. local factors on the global patterns of fern richness (@doi:10.1111/jbi.13782), the mechanisms underlying the spread and abundance of native vs. invasive tree species (@doi:10.1111/geb.13027), and worldwide trait–environment relationships in plant communities (@doi:10.1038/s41559-018-0699-8).  
 
@@ -43,6 +43,6 @@ The selected vegetation plots stem from 104 databases and span 115 countries (Fi
 This resampled dataset (sPlot Open - hereafter) is composed of: 
 (1) plot-level information, including metadata and basic vegetation structure descriptors; 
 (2) the vascular plant species composition of each vegetation plot, including species cover or abundance information when available; and 
-(3) community-level functional information derived from the TRY database (@https://doi.org/10.1111/gcb.14904).  
+(3) community-level functional information obtained by intersection with the TRY database (@https://doi.org/10.1111/gcb.14904).  
 
 ![Global map of sPlot Open (n = 91,205) and spatial distribution of vegetation plot density per hexagonal cell with a spatial resolution of approximately 70.000 km². Map projection is Eckert IV.](images/figure1.png){#fig:Figure1}

--- a/content/02.BackgroundSummary.md
+++ b/content/02.BackgroundSummary.md
@@ -3,7 +3,7 @@
 
 Biodiversity is facing a global crisis. 
 As many as 1 million species are currently threatened with extinction, the vast majority due to anthropogenic impacts such as land-use and climate change (@ipbes2019, @isbn:9782940529902). 
-In addition, the rates of species migration and biotic homogenization are accelerating (@doi:10.1038/s41586-020-2640-y, @doi:10.1038/s41559-020-1198-2; @doi:10.1038/s41559-020-1176-8). 
+In addition, the rates of biodiversity homogenization and redistribution are accelerating (@doi:10.1038/s41586-020-2640-y, @doi:10.1038/s41559-020-1198-2; @doi:10.1038/s41559-020-1176-8). 
 Biological assemblages are becoming progressively more similar to each other globally, as local and endemic species go extinct and are replaced by more widespread and competitive native or alien species (@ipbes2019; @doi:10.1038/s41559-020-1176-8). 
 Many terrestrial and marine species are also shifting their geographical distribution as a response to climate change (@doi:10.1038/s41559-020-1198-2), including animals hosting pathogens transmissible to humans (@doi:10.1038/nature06536; @doi:10.1126/science.1244325). 
 This has profound potential impacts on ecosystems and human health (@doi:10.1126/science.aai9214;  @doi:10.1111/brv.12344). 
@@ -27,9 +27,9 @@ Being spatially explicit, vegetation plots can be resurveyed through time to ass
 As they normally contain information on the relative cover or abundance of each species, vegetation plots are also more appropriate for detecting biodiversity changes than data representing only the occurrence of individual species (@doi:10.1111/j.1654-1103.2011.01318.x).  
 
 Globally, however, vegetation-plot data are very fragmented, as they typically stem from a myriad of local research and survey projects (@doi:10.1111/jvs.12710). 
-Consequently, these data often have either high fine-grain spatial resolutions but small spatial extents, or vice versa (@doi:10.1371/journal.pbio.3000183). 
+Consequently, these data often have either high fine-grain spatial resolutions but small spatial extents, or broad extents but coarse grains (@doi:10.1371/journal.pbio.3000183). 
 Furthermore, with their disparate sampling protocols, standards and taxonomic resolutions, aggregating and harmonizing vegetation plot data proves extremely challenging (@doi:10.1038/s41559-018-0699-8). 
-It is not surprising, therefore, that these data are rarely used in global‐scale biodiversity research (@doi:10.1111/geb.12501; @doi:10.1111/jvs.12419; @doi:10.1111/jvs.12864).  
+It is not surprising, therefore, that these data are rarely used in global‐scale research on the biodiversity of plant communities (@doi:10.1111/geb.12501; @doi:10.1111/jvs.12419; @doi:10.1111/jvs.12864).  
 
 The sPlot initiative tries to close this data gap. 
 It consolidates numerous local to regional vegetation-plot datasets to create a harmonized and comprehensive global database of georeferenced terrestrial plant species assemblages (@doi:10.1111/jvs.12710). 


### PR DESCRIPTION
I would like to add the following remarks:
1. I am concerned about indiscriminate use of "vegetation": biogeochemists and remote sensing scientists make NO distinction between crops and spontaneous vegetation, i.e. they use it +/- synonymously with land covered by plant biomass - I also believe that Yinon et al. [12] include crops in their estimate of global biomass. Our restricted concept of vegetation should be made clear to avoid false expectations with respect to ground truthing and to point out the qualitative nature of our vegetation data.
2. Why were plots without abundance and without full coverage of vascular plants included in the selection (probably because some biomes have too few complete plot data)? This causes two problems, that may easily be overlooked: Their species richness and CWM cannot be compared to other plots, i.e. they have to be filtered out before analysing the database. If there is spatial bias in their origin, removing larger numbers of incomplete plots can make the design unabalanced and bias results in a non-straightforward way. 
3. I do not get what "vice versa" in line 30 ("have either high fine-grain spatial resolutions but small spatial extents, or vice versa") means: vegetation data never have coarse resolutions, do they?
4. Is the statement in l.32 correct that plot data "are rarely used in global‐scale biodiversity research" - I believe they make a substantial bulk contribution to GBIF, where, however, they are used wthout really exploiting their information content.