### PR TITLE
Update 04.DataRecords.md

### DIFF
--- a/content/04.DataRecords.md
+++ b/content/04.DataRecords.md
@@ -13,11 +13,11 @@ In contrast, in Africa and South America the remaining plots after data edition 
 The representation of biomes is also unbalanced (Figure {@fig:Figure2}). 
 Despite these imbalances, all the Whittaker biomes are covered by sPlot Open, and our resampling algorithm has resulted in a much more balanced dataset than many other large global datasets that are available, such as GBIF. 
 
-![Distribution of all the vegetation plots provided by sPlot Open (n = 91,205) in the bi-dimensional climatic space represented by mean annual temperature and mean annual precipitation superimposed onto Whittaker biomes (@Whittaker1975)](images/figure2.png){#fig:Figure2}
+![Distribution of all the vegetation plots provided by sPlot Open (n = 91,205) in the two-dimensional climatic space represented by mean annual temperature and mean annual precipitation superimposed onto Whittaker biomes (@Whittaker1975)](images/figure2.png){#fig:Figure2}
 
-Finally, vegetation plots in sPlot Open belong to forest (n = 25,740) or non forest (n = 58,145) vegetation, with a minor proportion of plots remaining unassigned (n = 7,320). 
+Almost one third of vegetation plots in sPlot Open belong to forest (n = 25,740), two thirds to non-forest vegetation (n = 58,145) vegetation, with 8 % of plots remaining unassigned (n = 7,320). 
 When not directly done by data providers, the assignment of plots to forests and non-forests was based on multiple lines of evidence, including the plot-level information on the cover of the tree layer, as well as traits of species composing a plot, such as growth form and height. 
-In short, a plot record was considered as forest if the cover of the tree layer, or alternatively, the sum of the relative cover of all tree taxa (normalized to 100%), was greater than 25%. It was considered a non-forest record if the sum of relative cover of low‐stature, non‐tree and non‐shrub taxa was greater than 90%. 
+In short, a plot record was considered as forest if the cover of the tree layer, or alternatively, the sum of the (relative) cover of all tree taxa (normalized to 100%), was greater than 25%. It was considered a non-forest record if the sum of relative cover of low‐stature, non‐tree and non‐shrub taxa was greater than 90%. 
 For an extensive explanation of this classification scheme, we refer the reader to Bruelheide et al. (2019) \[@doi:10.1111/jvs.12710\]. 
 Even if the proportion of forest vs. non-forest vegetation plots is relatively well-balanced, the geographical distribution of vegetation plots belonging to different vegetation types is likely not balanced in the geographical space, as it depends on the idiosyncrasies of the constitutive datasets composing the sPlot database. 
 For instance, the data from New Zealand only include plots collected in non-forest ecosystems, while data from Chile only refer to forests. 


### PR DESCRIPTION
I am concerned about 
- the immense range of plot sizes, which contain unreasonably small as well as large "plots" - please list proportions of size classes in Table 2.
- inclusion of plots with selective recording of vascular plant species - in any case, list the proportions of plots in Table 2; crucial advantages of vegetation plots mentioned in Background & Summary (e.g. true absences) do not pertain to such selective plots; diversity measures and CWM of traits of such plots are incompatible with complete plots; they also interfere with resampling through distorted dissimilarity patterns etc. I can see they are better then nothing in undersampled biomes, but having them in the database poses the risk of misleading results.
Are Whittaker biomes the best choice for Figure 2, when so many plots (temperate-montane and alpine?) are way outside of their climatic domain? A frequency distribution of plots across biomes would certainly be important (cf. variable Biome in Table 2).
In Braun-Blanquet relevés cover of species is not relative, but always refers to projection on the plot area.